### PR TITLE
:hammer: Add githooks for astro check and gitmoji

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+npm run astro check

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+# gitmoji as a commit hook
+exec < /dev/tty
+gitmoji --hook $1 $2

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "prepare-hooks": "git config --local core.hooksPath .githooks"
   },
   "devDependencies": {
     "@types/sanitize-html": "^2.6.2",


### PR DESCRIPTION
`gitmoji-cli` has to be [installed](https://github.com/carloscuesta/gitmoji-cli). 

I added a npm script to enable the hooks (`npm run prepare-hooks`).